### PR TITLE
Prefix _view with an optional namespace argument, so multiple pgsync instances can target the same db.

### DIFF
--- a/pgsync/base.py
+++ b/pgsync/base.py
@@ -129,7 +129,7 @@ class TupleIdentifierType(sa.types.UserDefinedType):
 
 class Base(object):
     def __init__(
-        self, database: str, verbose: bool = False, *args, **kwargs
+        self, database: str, verbose: bool = False, namespace: str = None, *args, **kwargs
     ) -> None:
         """Initialize the base class constructor."""
         self.__engine: sa.engine.Engine = _pg_engine(
@@ -146,6 +146,7 @@ class Base(object):
         self.__columns: dict = {}
         self.verbose: bool = verbose
         self._conn = None
+        self.namespace = namespace
 
     def connect(self) -> None:
         """Connect to database."""
@@ -521,6 +522,13 @@ class Base(object):
             ).scalar()
 
     # Views...
+    @property
+    def materialized_view_name(self) -> str:
+        """Get the materialized view name with optional namespace prefix."""
+        if self.namespace:
+            return f"_{self.namespace}{MATERIALIZED_VIEW}"
+        return MATERIALIZED_VIEW
+
     def create_view(
         self,
         index: str,
@@ -537,13 +545,22 @@ class Base(object):
             tables,
             user_defined_fkey_tables,
             self._materialized_views(schema),
+            self.materialized_view_name,
         )
+
+        # Clear materialized views cache
+        if schema in self.__materialized_views:
+            del self.__materialized_views[schema]
 
     def drop_view(self, schema: str) -> None:
         """Drop a view."""
-        logger.debug(f"Dropping view: {schema}.{MATERIALIZED_VIEW}")
-        self.engine.execute(DropView(schema, MATERIALIZED_VIEW))
-        logger.debug(f"Dropped view: {schema}.{MATERIALIZED_VIEW}")
+        logger.debug(f"Dropping view: {schema}.{self.materialized_view_name}")
+        self.engine.execute(DropView(schema, self.materialized_view_name))
+        logger.debug(f"Dropped view: {schema}.{self.materialized_view_name}")
+
+        # Clear materialized views cache
+        if schema in self.__materialized_views:
+            del self.__materialized_views[schema]
 
     def refresh_view(
         self, name: str, schema: str, concurrently: bool = False
@@ -614,12 +631,9 @@ class Base(object):
 
     def create_function(self, schema: str) -> None:
         self.execute(
-            CREATE_TRIGGER_TEMPLATE.replace(
-                MATERIALIZED_VIEW,
-                f"{schema}.{MATERIALIZED_VIEW}",
-            ).replace(
-                TRIGGER_FUNC,
-                f"{schema}.{TRIGGER_FUNC}",
+            CREATE_TRIGGER_TEMPLATE.format(
+                materialized_view=f"{schema}.{self.materialized_view_name}",
+                trigger_func=f"{schema}.{TRIGGER_FUNC}",
             )
         )
 

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -22,7 +22,6 @@ from .base import Base, Payload
 from .constants import (
     DELETE,
     INSERT,
-    MATERIALIZED_VIEW,
     MATERIALIZED_VIEW_COLUMNS,
     META,
     PRIMARY_KEY_DELIMITER,
@@ -170,13 +169,13 @@ class Sync(Base, metaclass=Singleton):
 
         for node in self.tree.traverse_breadth_first():
             # ensure internal materialized view compatibility
-            if MATERIALIZED_VIEW in self._materialized_views(node.schema):
+            if self.materialized_view_name in self._materialized_views(node.schema):
                 if MATERIALIZED_VIEW_COLUMNS != self.columns(
-                    node.schema, MATERIALIZED_VIEW
+                    node.schema, self.materialized_view_name
                 ):
                     raise RuntimeError(
                         f"Required materialized view columns not present on "
-                        f"{MATERIALIZED_VIEW}. Please re-run bootstrap."
+                        f"{self.materialized_view_name}. Please re-run bootstrap."
                     )
 
             if node.schema not in self.schemas:
@@ -1365,6 +1364,10 @@ class Sync(Base, metaclass=Singleton):
     type=int,
     default=settings.NTHREADS_POLLDB,
 )
+@click.option(
+    "--namespace",
+    help="Namespace for materialized views",
+)
 def main(
     config,
     daemon,
@@ -1379,6 +1382,7 @@ def main(
     analyze,
     nthreads_polldb,
     polling,
+    namespace,
 ):
     """Main application syncer."""
     if version:
@@ -1391,6 +1395,7 @@ def main(
         "port": port,
         "sslmode": sslmode,
         "sslrootcert": sslrootcert,
+        "namespace": namespace,
     }
     if password:
         kwargs["password"] = click.prompt(

--- a/pgsync/trigger.py
+++ b/pgsync/trigger.py
@@ -1,8 +1,7 @@
 """PGSync Trigger template."""
-from .constants import MATERIALIZED_VIEW, TRIGGER_FUNC
 
-CREATE_TRIGGER_TEMPLATE = f"""
-CREATE OR REPLACE FUNCTION {TRIGGER_FUNC}() RETURNS TRIGGER AS $$
+CREATE_TRIGGER_TEMPLATE = """
+CREATE OR REPLACE FUNCTION {trigger_func}() RETURNS TRIGGER AS $$
 DECLARE
   channel TEXT;
   old_row JSON;
@@ -21,7 +20,7 @@ BEGIN
 
         SELECT primary_keys, indices
         INTO _primary_keys, _indices
-        FROM {MATERIALIZED_VIEW}
+        FROM {materialized_view}
         WHERE table_name = TG_TABLE_NAME;
 
         old_row = ROW_TO_JSON(OLD);
@@ -36,7 +35,7 @@ BEGIN
 
             SELECT primary_keys, foreign_keys, indices
             INTO _primary_keys, _foreign_keys, _indices
-            FROM {MATERIALIZED_VIEW}
+            FROM {materialized_view}
             WHERE table_name = TG_TABLE_NAME;
 
             new_row = ROW_TO_JSON(NEW);

--- a/pgsync/view.py
+++ b/pgsync/view.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext import compiler
 from sqlalchemy.schema import DDLElement
 from sqlalchemy.sql.selectable import Select
 
-from .constants import DEFAULT_SCHEMA, MATERIALIZED_VIEW
+from .constants import DEFAULT_SCHEMA
 
 logger = logging.getLogger(__name__)
 
@@ -199,6 +199,7 @@ def create_view(
     tables: Set,
     user_defined_fkey_tables: dict,
     views: List[str],
+    view_name: str,
 ) -> None:
     """
     View describing primary_keys and foreign_keys for each table
@@ -224,10 +225,10 @@ def create_view(
     """
 
     rows: dict = {}
-    if MATERIALIZED_VIEW in views:
+    if view_name in views:
         for table_name, primary_keys, foreign_keys, indices in fetchall(
             sa.select(["*"]).select_from(
-                sa.text(f"{schema}.{MATERIALIZED_VIEW}")
+                sa.text(f"{schema}.{view_name}")
             )
         ):
             rows.setdefault(
@@ -245,7 +246,7 @@ def create_view(
             if indices:
                 rows[table_name]["indices"] = set(indices)
 
-        engine.execute(DropView(schema, MATERIALIZED_VIEW))
+        engine.execute(DropView(schema, view_name))
 
     if schema != DEFAULT_SCHEMA:
         for table in set(tables):
@@ -315,18 +316,18 @@ def create_view(
         )
         .alias("t")
     )
-    logger.debug(f"Creating view: {schema}.{MATERIALIZED_VIEW}")
-    engine.execute(CreateView(schema, MATERIALIZED_VIEW, statement))
+    logger.debug(f"Creating view: {schema}.{view_name}")
+    engine.execute(CreateView(schema, view_name, statement))
     engine.execute(DropIndex("_idx"))
     engine.execute(
         CreateIndex(
             "_idx",
             schema,
-            MATERIALIZED_VIEW,
+            view_name,
             ["table_name"],
         )
     )
-    logger.debug(f"Created view: {schema}.{MATERIALIZED_VIEW}")
+    logger.debug(f"Created view: {schema}.{view_name}")
 
 
 def is_view(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -560,3 +560,37 @@ class TestBase(object):
         )
 
         _pg_engine("mydb", sslmode="allow", sslrootcert=__file__)
+
+    def test_create_view_with_namespace(self, connection):
+        """Test creating view with namespace."""
+        pg_base = Base(connection.engine.url.database, namespace="test")
+        pg_base.create_view(
+            "testdb",
+            DEFAULT_SCHEMA,
+            {"book"},
+            {},
+        )
+        assert "_test_view" in pg_base._materialized_views(DEFAULT_SCHEMA)
+        pg_base.drop_view(DEFAULT_SCHEMA)
+
+    def test_drop_view_with_namespace(self, connection):
+        """Test dropping view with namespace."""
+        pg_base = Base(connection.engine.url.database, namespace="test")
+        pg_base.create_view(
+            "testdb",
+            DEFAULT_SCHEMA,
+            {"book"},
+            {},
+        )
+        pg_base.drop_view(DEFAULT_SCHEMA)
+        assert "_test_view" not in pg_base._materialized_views(DEFAULT_SCHEMA)
+
+    def test_create_function_with_namespace(self, connection):
+        """Test creating function with namespace."""
+        pg_base = Base(connection.engine.url.database, namespace="test")
+        with patch("pgsync.base.Base.execute") as mock_execute:
+            pg_base.create_function(DEFAULT_SCHEMA)
+            mock_execute.assert_called_once()
+            # Verify the materialized view name in the function
+            call_args = mock_execute.call_args[0][0]
+            assert f"{DEFAULT_SCHEMA}._test_view" in str(call_args)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4,6 +4,7 @@ import os
 from collections import namedtuple
 from typing import List
 
+from pgsync.constants import DEFAULT_SCHEMA
 import pytest
 from mock import ANY, call, patch
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -85,7 +85,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 """
-        assert CREATE_TRIGGER_TEMPLATE == expected
+        actual = CREATE_TRIGGER_TEMPLATE.format(
+            materialized_view="_view",
+            trigger_func="table_notify",
+        )
+        assert actual == expected
 
     def test_trigger_primary_key_function(self, connection):
         tables = {

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -240,6 +240,7 @@ class TestView(object):
                 ["book", "publisher"],
                 user_defined_fkey_tables={},
                 views=[],
+                view_name="_view",
             )
             assert mock_logger.debug.call_count == 2
             assert mock_logger.debug.call_args_list == [
@@ -260,6 +261,7 @@ class TestView(object):
                 set(["book", "publisher"]),
                 user_defined_fkey_tables=user_defined_fkey_tables,
                 views=[],
+                view_name="_view",
             )
             assert mock_logger.debug.call_count == 2
             assert mock_logger.debug.call_args_list == [


### PR DESCRIPTION
Currently, we run multiple pgsync instances so we can red/black deploy individual indexes during deployment.

However, this can lead to collisions, because they use a hardcoded view `_view`, that they all want to use, in the `public` schema.

This allows `pgsync --namespace mynamespace` to be used when running pgsync, and will then prefix that view name with that namespace, to avoid collisions.

:warning: there may be other things that need to have the same treatment, it's possible that `_idx` might need changing too.