### PR TITLE
Skip pg_logical_emit_message rows in logical_slot_changes

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -57,6 +57,17 @@ from .utils import (
     Timer,
 )
 
+# Logical decoding messages emitted via pg_logical_emit_message (e.g. CDC
+# heartbeats from tools like Datastream). These are non-DML records and must
+# be ignored rather than parsed as row changes. The transactional flag tells
+# us whether the message is wrapped in a BEGIN/COMMIT (transactional: 1) or
+# emitted standalone (transactional: 0); standalone messages have no COMMIT to
+# ACK their LSN, so we must acknowledge them explicitly.
+LOGICAL_MSG_RE = re.compile(
+    r"^message:(?:\s+transactional:\s+(?P<transactional>[01]))?\s",
+    re.IGNORECASE,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -392,8 +403,10 @@ class Sync(Base, metaclass=Singleton):
 
             rows: list = []
             for row in changes:
-                if re.search(r"^BEGIN", row.data) or re.search(
-                    r"^COMMIT", row.data
+                if (
+                    re.search(r"^BEGIN", row.data)
+                    or re.search(r"^COMMIT", row.data)
+                    or LOGICAL_MSG_RE.match(row.data)
                 ):
                     continue
                 rows.append(row)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -107,6 +107,29 @@ class TestSync(object):
             mock_peek.side_effect = [
                 [
                     ROW(
+                        "message: transactional: 1 prefix: heartbeat, sz: 29 "  # noqa E501
+                        "content:2026-06-22 09:29:59.469543+00",
+                        1234,
+                    ),
+                ],
+                [],
+            ]
+            with patch("pgsync.sync.Sync.sync") as mock_sync:
+                sync.logical_slot_changes()
+                mock_peek.assert_any_call(
+                    "testdb_testdb",
+                    txmin=None,
+                    txmax=None,
+                    upto_nchanges=None,
+                    limit=settings.LOGICAL_SLOT_CHUNK_SIZE,
+                    offset=0,
+                )
+                mock_sync.assert_not_called()
+
+        with patch("pgsync.sync.Sync.logical_slot_peek_changes") as mock_peek:
+            mock_peek.side_effect = [
+                [
+                    ROW(
                         "table public.book: INSERT: id[integer]:10 isbn[character "  # noqa E501
                         "varying]:'888' title[character varying]:'My book title' "  # noqa E501
                         "description[character varying]:null copyright[character "  # noqa E501


### PR DESCRIPTION
## Problem

On a shared Aurora database, RisingWave's postgres-cdc connector calls `pg_logical_emit_message()` every 60s as a heartbeat (to advance its own slot and prevent WAL bloat). That WAL record is decoded by **every** logical replication slot on the database — including pgsync's.

pgsync reads its slot via `test_decoding`, where the heartbeat renders as:

```
message: transactional: 1 prefix: heartbeat, sz: 29 content:2026-06-22 09:29:59.469543+00
```

`parse_logical_slot` only matches DML and raises `LogicalSlotParseError` on no match. `logical_slot_changes` re-raises, the process exits, supervisord respawns it, and it reads the same stuck slot position again → infinite crash-loop. The slot's `restart_lsn` never advances and WAL accumulates.

```
pgsync.exc.LogicalSlotParseError: 'No match for row: message: transactional: 1
   prefix: heartbeat, sz: 29 content:2026-06-22 09:29:59.469543+00'
INFO exited: pgsync (exit status 1; not expected)
INFO spawned: 'pgsync' with pid ...
```

## Fix

This is **already fixed on upstream `toluaina/pgsync` main**, which introduced a `LOGICAL_MSG_RE` constant and filters logical-decoding messages alongside `BEGIN`/`COMMIT`. Upstream has since rewritten `logical_slot_changes` wholesale, so this fork can't cherry-pick the whole method without a large divergence.

To minimize drift, this PR ports upstream's **exact** `LOGICAL_MSG_RE` constant (byte-identical, including the doc comment) and uses upstream's exact `LOGICAL_MSG_RE.match(row.data)` check in the fork's existing pre-parse filter. When the fork later catches up to upstream main, this patch reconciles cleanly instead of conflicting.

The existing `BEGIN`/`COMMIT` `re.search` lines are left as-is — they predate this fix and aren't part of it (upstream's `TX_BOUNDARY_RE` is a separate change that would alter behavior).

The filter runs on `changes` before the parse loop, and both the primary parse and the look-ahead parse read the filtered `rows`, so both parse sites are covered. The slot still advances normally via the separate `logical_slot_get_changes` consume step.

## Test

Extends `test_logical_slot_changes` with a `message: transactional: 1 prefix: heartbeat ...` row, asserting it is skipped (no `LogicalSlotParseError`, no sync emitted) — mirroring the existing `BEGIN`/`COMMIT` skip cases.

## Notes

- Does **not** require disabling RisingWave's CDC heartbeat (which prevents WAL bloat).
- Avoids dropping/recreating the slot, which would force a full resync.
- Follow-up worth a separate ticket: catch this fork up to upstream main, which would make this backport redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)