### PR TITLE
Fix QueryBuilder foreign key cache corruption

### DIFF
--- a/pgsync/querybuilder.py
+++ b/pgsync/querybuilder.py
@@ -1,5 +1,6 @@
 """PGSync QueryBuilder."""
 
+import copy
 import threading
 import typing as t
 from collections import defaultdict
@@ -121,7 +122,7 @@ class QueryBuilder(threading.local):
         """
         cache_key: t.Tuple[t.Any, t.Any] = (node_a, node_b)
         if cache_key in self._cache:
-            return self._cache[cache_key]
+            return copy.deepcopy(self._cache[cache_key])
 
         fkeys: t.MutableMapping[str, t.List[str]] = defaultdict(list)
 
@@ -226,7 +227,7 @@ class QueryBuilder(threading.local):
 
         result: t.Dict[str, t.List[str]] = dict(fkeys)
         self._cache[cache_key] = result
-        return result
+        return copy.deepcopy(result)
 
     def _get_foreign_keys(self, node_a: Node, node_b: Node) -> dict:
         """This is for handling through nodes."""
@@ -254,7 +255,7 @@ class QueryBuilder(threading.local):
 
             self._cache[(node_a, node_b)] = foreign_keys
 
-        return self._cache[(node_a, node_b)]
+        return copy.deepcopy(self._cache[(node_a, node_b)])
 
     def _get_column_foreign_keys(
         self,
@@ -284,15 +285,17 @@ class QueryBuilder(threading.local):
         if table is None:
             for table, cols in foreign_keys.items():
                 if set(cols).issubset(set(column_names)):
-                    return foreign_keys[table]
+                    return list(foreign_keys[table])
         else:
             # only return the intersection of columns that match
             if not table.startswith(f"{schema}."):
                 table = f"{schema}.{table}"
-            for i, value in enumerate(foreign_keys[table]):
-                if value not in columns:
-                    foreign_keys[table].pop(i)
-            return foreign_keys[table]
+            column_name_set = set(column_names)
+            return [
+                value
+                for value in foreign_keys[table]
+                if value in column_name_set
+            ]
 
     def _get_child_keys(
         self, node: Node, params: dict

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,10 +1,96 @@
 """QueryBuilder tests."""
 
+from types import SimpleNamespace
+
 import pytest
+import sqlalchemy as sa
 
 from pgsync.base import Base
 from pgsync.node import Node
 from pgsync.querybuilder import QueryBuilder
+
+
+def test_get_foreign_keys_returns_copy_for_new_and_cached_values():
+    metadata = sa.MetaData()
+    parent = sa.Table(
+        "parent",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        schema="public",
+    )
+    child = sa.Table(
+        "child",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("parent_id", sa.ForeignKey("public.parent.id")),
+        schema="public",
+    )
+    relationship = SimpleNamespace(foreign_key=None)
+
+    class NodeStub:
+        def __init__(self, table):
+            self.model = SimpleNamespace(original=table)
+            self.relationship = relationship
+
+    parent_node = NodeStub(parent)
+    child_node = NodeStub(child)
+    query_builder = QueryBuilder()
+
+    first = query_builder.get_foreign_keys(child_node, parent_node)
+    first["public.child"].clear()
+
+    second = query_builder.get_foreign_keys(child_node, parent_node)
+
+    assert second == {
+        "public.child": ["parent_id"],
+        "public.parent": ["id"],
+    }
+
+
+def test_get_through_foreign_keys_returns_cache_copy():
+    query_builder = QueryBuilder()
+    node_a = object()
+    node_b = object()
+    cache_key = (node_a, node_b)
+    query_builder._cache[cache_key] = {
+        "public.join_table": ["parent_id", "child_id"]
+    }
+
+    first = query_builder._get_foreign_keys(node_a, node_b)
+    first["public.join_table"].clear()
+
+    second = query_builder._get_foreign_keys(node_a, node_b)
+
+    assert second == {"public.join_table": ["parent_id", "child_id"]}
+
+
+def test_get_column_foreign_keys_does_not_mutate_input():
+    query_builder = QueryBuilder()
+    foreign_keys = {
+        "public.join_table": ["A", "B", "X", "Y"],
+    }
+
+    result = query_builder._get_column_foreign_keys(
+        ["B"],
+        foreign_keys,
+        table="join_table",
+        schema="public",
+    )
+
+    assert result == ["B"]
+    assert foreign_keys == {
+        "public.join_table": ["A", "B", "X", "Y"],
+    }
+
+    unscoped_result = query_builder._get_column_foreign_keys(
+        ["A", "B", "X", "Y"],
+        foreign_keys,
+    )
+    unscoped_result.clear()
+
+    assert foreign_keys == {
+        "public.join_table": ["A", "B", "X", "Y"],
+    }
 
 
 @pytest.mark.usefixtures("table_creator")


### PR DESCRIPTION
## Summary

This PR fixes a mutable-cache ownership bug in `QueryBuilder` that can corrupt foreign-key metadata across repeated document builds.

The bug is stateful: one call receives a mutable object owned by `QueryBuilder._cache`, and `_get_column_foreign_keys()` removes entries from that object in place. A later call on the same worker then reads the already-truncated cache entry. In MeetsOne's custom-document index this was reproduced with **one worker**: the first call produced the expected tag relation, while the second call produced the exact `[null, null]` value.

This change:

- returns deep copies of cached foreign-key mappings from both the direct and through-table paths;
- also returns a deep copy when a cache entry is first computed, so the first caller cannot mutate the stored value;
- makes `_get_column_foreign_keys()` a non-mutating filter instead of calling `pop()` while iterating;
- compares against normalized `column_names`, which also handles SQLAlchemy `Column` inputs correctly;
- adds regression tests for new cache entries, cache hits, through-table cache entries, and non-mutating column filtering.

## Root cause

Before this change, the cached dictionary and its nested lists were returned by reference:

```python
foreign_keys = query_builder._get_foreign_keys(...)
# foreign_keys may be the exact object stored in query_builder._cache
```

The table-specific path then mutated that shared object:

```python
for i, value in enumerate(foreign_keys[table]):
    if value not in columns:
        foreign_keys[table].pop(i)
```

There are two problems here:

1. The cached list is permanently modified, so later records processed by the same worker can use incomplete relationship metadata.
2. Removing entries while iterating can skip adjacent entries and makes the result order-dependent.

Returning isolated values and filtering into a new list makes the cache immutable from the caller's perspective.

## Historical context: the fix existed before, but is not in the current lineage

An important nuance is that the old fix was **not deleted from the historical branch**. It is still present on [`through-table-without-primary-key`](https://github.com/meetsmore/pgsync/tree/through-table-without-primary-key). However, the current `main` branch was later created from an upstream lineage that never contained that commit.

The ancestry checks make the distinction explicit:

```console
$ git merge-base --is-ancestor 11221e6c3dff7c607fde1b12e7090de96b197011 e2636d831c88ef78737cda54e4fbd87e30d50803
# exit 1: the old cache fix is NOT an ancestor of current main

$ git merge-base --is-ancestor 11221e6c3dff7c607fde1b12e7090de96b197011 origin/through-table-without-primary-key
# exit 0: the old cache fix is still an ancestor of the historical branch
```

### Timeline

| Date | Event | Cache-fix status |
| --- | --- | --- |
| 2023-05-01 | MeetsMore's historical branch added support for through tables without primary keys in [`70a9673`](https://github.com/meetsmore/pgsync/commit/70a96732c05ee93dd70dec055bc16ee044f69521). | The mutable-cache bug was still present. |
| 2024-07-16 | [`11221e6`](https://github.com/meetsmore/pgsync/commit/11221e6c3dff7c607fde1b12e7090de96b197011) added `deepcopy` when returning foreign-key cache entries. Its commit message specifically says the mutation in `_get_column_foreign_keys()` “breaks cache objects.” | Fixed on the historical branch. |
| 2025-02-06 | MeetsOne changed the source repository from `ton1517/pgsync` to `meetsmore/pgsync` in [meetsone#14185](https://github.com/meetsmore/meetsone/pull/14185), while keeping the same `through-table-without-primary-key` branch. | The historical fix remained in use. |
| 2025-05-20 | [meetsone#15933](https://github.com/meetsmore/meetsone/pull/15933) moved the dependency declaration into `pgsync/requirements.txt`, still using the fixed historical branch. | The historical fix remained in use. |
| 2025-05-26 | [meetsone#16145](https://github.com/meetsmore/meetsone/pull/16145) replaced the historical fork branch with upstream PGSync 4.0.0 ([`38d193c`](https://github.com/toluaina/pgsync/commit/38d193c4272fd6df9a67ae278fe0e09edfacccda)). This changed Git lineage rather than reverting `11221e6` on its original branch. | **The cache fix was no longer present in the selected dependency.** |
| 2025-05 to 2025-08 | The upstream pin was advanced several times in [#16179](https://github.com/meetsmore/meetsone/pull/16179), [#16449](https://github.com/meetsmore/meetsone/pull/16449), [#16596](https://github.com/meetsmore/meetsone/pull/16596), [#16755](https://github.com/meetsmore/meetsone/pull/16755), [#17060](https://github.com/meetsmore/meetsone/pull/17060), and [#17656](https://github.com/meetsmore/meetsone/pull/17656). | These upstream revisions did not restore the cache-isolation fix. |
| 2025-09-18 | [meetsone#18331](https://github.com/meetsmore/meetsone/pull/18331) reported the same externally visible symptom: `DocumentTemplateTags` were stored as `[null, null]`. The pin was advanced for a grandparent-relationship fix. | That revision changed relationship handling, but still returned mutable cache entries and filtered them in place; the underlying cache-ownership bug remained. |
| 2025-10-01 | [meetsone#18642](https://github.com/meetsmore/meetsone/pull/18642) reverted PGSync to `c747405` because the newer revision caused operational problems. The related context is in this [Slack thread](https://meetsmore.slack.com/archives/C029SFUP8A2/p1759111958239389). | The cache bug remained. |
| 2025-10-08 | [meetsone#18741](https://github.com/meetsmore/meetsone/pull/18741) advanced the dependency to upstream [`a576114`](https://github.com/toluaina/pgsync/commit/a57611412311497881ea2bc408143fdbc92f84b9). | The cache bug remained. |
| 2026-07-01 | [meetsone#24236](https://github.com/meetsmore/meetsone/pull/24236) changed the dependency back to this repository at [`e2636d8`](https://github.com/meetsmore/pgsync/commit/e2636d831c88ef78737cda54e4fbd87e30d50803). That commit is upstream `a576114` plus one unrelated logical-message heartbeat fix. | The repository owner changed back to `meetsmore`, but the old fixed branch was not merged, so the cache bug was still present. |
| 2026-08-07 | This PR ports the cache-isolation behavior to the current `main` lineage and additionally removes the in-place list mutation. | Fixed on current `main`, with regression coverage. |

In short, looking only at the repository owner is misleading:

```text
Historical fixed lineage:
70a9673 -> 11221e6 -> through-table-without-primary-key

Current main lineage:
... -> a576114 (upstream) -> e2636d8 (heartbeat fix) -> this PR
```

This PR reconnects the missing cache fix to the lineage actually used by current MeetsOne deployments.

## Validation

```console
$ PG_USER=postgres python -m pytest -q \
    tests/test_query_builder.py::test_get_foreign_keys_returns_copy_for_new_and_cached_values \
    tests/test_query_builder.py::test_get_through_foreign_keys_returns_cache_copy \
    tests/test_query_builder.py::test_get_column_foreign_keys_does_not_mutate_input
...                                                                      [100%]
3 passed in 0.05s

$ python -m black --check pgsync/querybuilder.py tests/test_query_builder.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.

$ python -m flake8 pgsync/querybuilder.py tests/test_query_builder.py
# no output

$ git diff --check
# no output
```

## Impact and follow-up

This change prevents future cache poisoning. It does not repair documents that have already been indexed with missing relationship values. Consumers should rebuild and deploy a PGSync image pinned to the merged commit, then reindex affected indexes separately.
