### PR TITLE
Self-heal corrupt checkpoint file after ungraceful shutdowns

### DIFF
--- a/pgsync/exc.py
+++ b/pgsync/exc.py
@@ -157,6 +157,14 @@ class PrimaryKeyNotFoundError(Exception):
         return repr(self.value)
 
 
+class CheckpointError(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)
+
+
 class LogicalSlotParseError(Exception):
     def __init__(self, value):
         self.value = value

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -1,16 +1,19 @@
 """Sync module."""
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
 import pprint
 import re
 import select
+import stat
 import sys
 import threading
 import time
 import typing as t
+import uuid
 from collections import defaultdict
 from itertools import groupby
 from pathlib import Path
@@ -35,6 +38,7 @@ from .constants import (
     UPDATE,
 )
 from .exc import (
+    CheckpointError,
     ForeignKeyError,
     InvalidSchemaError,
     InvalidTGOPError,
@@ -1248,6 +1252,84 @@ class Sync(Base, metaclass=Singleton):
 
             yield doc
 
+    def _heal_checkpoint_file(self) -> int:
+        """
+        Recover a corrupt checkpoint file from the replication slot.
+
+        :return: The healed checkpoint value.
+        :rtype: int
+        :raises CheckpointError: If the slot cannot be peeked or has no
+            pending changes to derive a checkpoint from.
+        """
+        logger.warning(
+            f"Corrupt checkpoint file: {self.checkpoint_file}. "
+            f"Attempting to heal it from replication slot "
+            f'"{self.slot_name}".'
+        )
+
+        rows: t.List[sa.engine.row.Row]
+        try:
+            rows = self.logical_slot_peek_changes(self.slot_name, limit=1)
+        except Exception as e:
+            logger.exception(
+                f"Cannot heal corrupt checkpoint file "
+                f"{self.checkpoint_file}: peeking replication slot "
+                f'"{self.slot_name}" failed: {e}'
+            )
+
+            # Error instead of attempting a full re-sync
+            raise CheckpointError(
+                f"Cannot heal corrupt checkpoint file "
+                f"{self.checkpoint_file}: peeking replication slot "
+                f'"{self.slot_name}" failed: {e}'
+            ) from e
+
+        if not rows:
+            logger.error(
+                f"Cannot heal corrupt checkpoint file "
+                f"{self.checkpoint_file}: replication slot "
+                f'"{self.slot_name}" has no pending changes to derive a '
+                f"checkpoint from. Set the checkpoint manually before "
+                f"restarting."
+            )
+            raise CheckpointError(
+                f"Cannot heal corrupt checkpoint file "
+                f"{self.checkpoint_file}: replication slot "
+                f'"{self.slot_name}" has no pending changes.'
+            )
+
+        xid: int = int(rows[0].xid)
+        checkpoint: int = xid - 1
+        logger.warning(
+            f"Healing checkpoint file {self.checkpoint_file}: oldest "
+            f'pending xid in replication slot "{self.slot_name}" is '
+            f"{xid}, resuming from checkpoint {checkpoint}."
+        )
+
+        self.checkpoint = checkpoint
+        return checkpoint
+
+    def _read_checkpoint_file(self) -> t.Optional[str]:
+        """
+        Read the raw checkpoint value from the checkpoint file.
+
+        A missing file means no checkpoint, which is a legitimate first
+        run. An empty or whitespace-only file is corrupt and gets healed
+        from the replication slot rather than treated as a first run.
+
+        :return: The raw checkpoint value or None if there is none.
+        :rtype: str or None
+        """
+        path: Path = Path(self.checkpoint_file)
+        if not path.exists():
+            return None
+
+        content: str = path.read_text(encoding="utf-8").strip()
+        if not content:
+            return str(self._heal_checkpoint_file())
+
+        return content.split()[0]
+
     @property
     def checkpoint(self) -> int:
         """
@@ -1260,12 +1342,7 @@ class Sync(Base, metaclass=Singleton):
         if settings.REDIS_CHECKPOINT:
             raw = self.redis.get_meta(default={}).get("checkpoint")
         else:
-            path: Path = Path(self.checkpoint_file)
-            raw = (
-                path.read_text(encoding="utf-8").split()[0]
-                if path.exists()
-                else None
-            )
+            raw = self._read_checkpoint_file()
 
         if raw is None:
             return None
@@ -1282,6 +1359,12 @@ class Sync(Base, metaclass=Singleton):
         """
         Sets the checkpoint value.
 
+        The file is written to a temporary path and renamed over the
+        target rather than truncated in place. POSIX requires rename(2)
+        to be atomic, so a process killed mid-write leaves either the
+        previous checkpoint or the new one behind and never a truncated
+        or empty file.
+
         :param value: The new checkpoint value.
         :type value: Optional[str]
         :raises TypeError: If the value is None.
@@ -1292,9 +1375,21 @@ class Sync(Base, metaclass=Singleton):
         if settings.REDIS_CHECKPOINT:
             self.redis.set_meta({"checkpoint": value})
         else:
-            Path(self.checkpoint_file).write_text(
-                f"{value}\n", encoding="utf-8"
-            )
+            path: Path = Path(self.checkpoint_file)
+            tmp: Path = Path(f"{path}.{uuid.uuid4().hex}.tmp")
+            mode: t.Optional[int] = None
+            
+            with contextlib.suppress(OSError):
+                mode = stat.S_IMODE(path.stat().st_mode)
+            try:
+                tmp.write_text(f"{value}\n", encoding="utf-8")
+                if mode is not None:
+                    os.chmod(tmp, mode)
+                os.replace(tmp, path)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    tmp.unlink()
+                raise
 
         # Update in-memory cache last
         self._checkpoint = value

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -1269,7 +1269,9 @@ class Sync(Base, metaclass=Singleton):
 
         rows: t.List[sa.engine.row.Row]
         try:
-            rows = self.logical_slot_peek_changes(self.slot_name, limit=1)
+            rows = self.logical_slot_peek_changes(
+                self.slot_name, upto_nchanges=1, limit=1
+            )
         except Exception as e:
             logger.exception(
                 f"Cannot heal corrupt checkpoint file "
@@ -1378,7 +1380,7 @@ class Sync(Base, metaclass=Singleton):
             path: Path = Path(self.checkpoint_file)
             tmp: Path = Path(f"{path}.{uuid.uuid4().hex}.tmp")
             mode: t.Optional[int] = None
-            
+
             with contextlib.suppress(OSError):
                 mode = stat.S_IMODE(path.stat().st_mode)
             try:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -10,6 +10,7 @@ from mock import ANY, call, patch
 
 from pgsync.base import Base, Payload
 from pgsync.exc import (
+    CheckpointError,
     InvalidTGOPError,
     PrimaryKeyNotFoundError,
     RDSError,
@@ -877,6 +878,85 @@ class TestSync(object):
             assert "Cannot assign a None value to checkpoint" == str(
                 excinfo.value
             )
+
+    @pytest.mark.parametrize("content", ["", "\n   \n"])
+    def test_checkpoint_corrupt_file_heals_from_slot(self, sync, content):
+        """A corrupt checkpoint file is healed from the replication slot.
+
+        A truncate-then-write killed mid-write leaves a 0 byte file
+        behind. Resume from the oldest change still pending in the slot
+        rather than crash-looping or resyncing from scratch.
+        """
+        with open(sync.checkpoint_file, "w") as fp:
+            fp.write(content)
+        sync._checkpoint = None
+
+        with patch.object(
+            sync,
+            "logical_slot_peek_changes",
+            return_value=[ROW("data", 673877104)],
+        ) as mock_peek:
+            assert sync.checkpoint == 673877103
+
+        mock_peek.assert_called_once_with(sync.slot_name, limit=1)
+        # the healed value is persisted so we only heal once
+        with open(sync.checkpoint_file, "r") as fp:
+            assert int(fp.read().split()[0]) == 673877103
+
+    def test_checkpoint_corrupt_file_raises_when_slot_is_empty(self, sync):
+        """Never silently resync: an unhealable checkpoint must raise."""
+        with open(sync.checkpoint_file, "w") as fp:
+            fp.write("")
+        sync._checkpoint = None
+
+        with patch.object(sync, "logical_slot_peek_changes", return_value=[]):
+            with pytest.raises(CheckpointError) as excinfo:
+                sync.checkpoint
+        assert "has no pending changes" in str(excinfo.value)
+
+    def test_checkpoint_corrupt_file_raises_when_peek_fails(self, sync):
+        with open(sync.checkpoint_file, "w") as fp:
+            fp.write("")
+        sync._checkpoint = None
+
+        with patch.object(
+            sync,
+            "logical_slot_peek_changes",
+            side_effect=Exception("connection lost"),
+        ):
+            with pytest.raises(CheckpointError) as excinfo:
+                sync.checkpoint
+        assert "failed" in str(excinfo.value)
+
+    def test_checkpoint_write_is_atomic(self, sync):
+        """A failed write must leave the previous checkpoint intact."""
+        sync.checkpoint = 1234
+
+        with patch("pgsync.sync.os.replace", side_effect=OSError("boom")):
+            with pytest.raises(OSError):
+                sync.checkpoint = 5678
+
+        sync._checkpoint = None
+        assert sync.checkpoint == 1234
+        assert self._temp_files(sync) == []
+
+    def test_checkpoint_write_leaves_no_temp_files(self, sync):
+        sync.checkpoint = 1234
+        sync.checkpoint = 5678
+        sync._checkpoint = None
+        assert sync.checkpoint == 5678
+        assert self._temp_files(sync) == []
+
+    @staticmethod
+    def _temp_files(sync) -> t.List[str]:
+        dirname: str = os.path.dirname(sync.checkpoint_file) or "."
+        basename: str = os.path.basename(sync.checkpoint_file)
+        return [
+            filename
+            for filename in os.listdir(dirname)
+            if filename.startswith(f"{basename}.")
+            and filename.endswith(".tmp")
+        ]
 
     def test__payload_data(self, sync):
         payload = Payload(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -898,7 +898,9 @@ class TestSync(object):
         ) as mock_peek:
             assert sync.checkpoint == 673877103
 
-        mock_peek.assert_called_once_with(sync.slot_name, limit=1)
+        mock_peek.assert_called_once_with(
+            sync.slot_name, upto_nchanges=1, limit=1
+        )
         # the healed value is persisted so we only heal once
         with open(sync.checkpoint_file, "r") as fp:
             assert int(fp.read().split()[0]) == 673877103


### PR DESCRIPTION
Incident thread: https://meetsmore.slack.com/archives/C0BUGCU8S00

Possible root cause: 

The checkpoint file was written non-atomically: `Path(self.checkpoint_file).write_text(f"{value}\n", encoding="utf-8")` write_text() truncates the file and then writes to it. A process killed in that window leaves a 0 byte file behind, which is what a node drain did to two slots on our shared EFS volume. 

On the next startup the read path did read_text().split()[0], which raises IndexError on empty content. pgsync exited 1, supervisord respawned it, and it crash-looped indefinitely. Nothing consumed the replication slots so WAL accumulated (~968MB per slot before we caught it) and the indexes went stale.

Upstream has no fix for this. The unsafe read has been there since the project was open sourced in 2020 and no atomic write has ever existed in pgsync/.REDIS_CHECKPOINT sidesteps the file entirely but defaults to off.

Fixes:
- Write side: write to a temporary file in the target's own directory and rename over it instead of truncating in place. POSIX requires rename(2) to be atomic, so a killed process now leaves either the previous checkpoint or the new one and never a truncated file.
- Read side: a missing checkpoint file still means "first run". An empty or whitespace-only file is now treated as corrupt and healed from the replication slot: peek the oldest pending change and resume at xid - 1.
- Never fall back to a full resync. If the slot cannot be peeked, or has no pending changes to derive a checkpoint from, log an error and raise CheckpointError so the failure is visible rather than silently rebuilding every index or getting stuck in a crash loop.

Tests
7 new checkpoint tests now pass. Full suite diffed against main to confirm no breaking tests.